### PR TITLE
travis update to xcode10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.1
 env: SWIFT_SNAPSHOT=4.2
 
 cache: cocoapods


### PR DESCRIPTION
Xcode 10.1 is more widely used than 10.0, especially since Xcode 10.0 was historically broken for Appstore releases targeting iOS 9.