### PR TITLE
Using https when possible

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
     <a href="https://travis-ci.org/EFPrefix/EFCountingLabel">
-    	<img src="http://img.shields.io/travis/EFPrefix/EFCountingLabel.svg">
+    	<img src="https://img.shields.io/travis/EFPrefix/EFCountingLabel.svg">
     </a>
     <a href="http://cocoapods.org/pods/EFCountingLabel">
     	<img src="https://img.shields.io/cocoapods/v/EFCountingLabel.svg?style=flat">
@@ -19,11 +19,11 @@
     <a href="https://twitter.com/EyreFree777">
     	<img src="https://img.shields.io/badge/twitter-@EyreFree777-blue.svg?style=flat">
     </a>
-    <a href="http://weibo.com/eyrefree777">
+    <a href="https://www.weibo.com/eyrefree777">
     	<img src="https://img.shields.io/badge/weibo-@EyreFree-red.svg?style=flat">
     </a>
     <img src="https://img.shields.io/badge/made%20with-%3C3-orange.svg">
-    <a href="http://shang.qq.com/wpa/qunwpa?idkey=d0f732585dcb0c6f2eb26bc9e0327f6305d18260eeba89ed26a201b520c572c0">
+    <a href="https://shang.qq.com/wpa/qunwpa?idkey=d0f732585dcb0c6f2eb26bc9e0327f6305d18260eeba89ed26a201b520c572c0">
         <img src="https://img.shields.io/badge/QQ群-769966374-32befc.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAA4VBMVEUAAAAAAAAAAAD3rwgAAAAAAADpICBuTQNUDAwAAAAAAAAAAAAAAADnICAAAAAAAACbFRUAAAD5rgkfFgEAAADHGxu1GBhGOyQ6LhMPCgAAAAB0UQRbDAziHh7hHh5HRUEAAAAPAgIQCwEQEBAdBAQgICAvIQIvLy8+LAJAQEBJCgpWRBpbW1tfX19gYGBqZVptTARvb299VwSAgICEhISHh4ePhnGbbAWgoKCseAawsLC7gwbAwMDExMTFrKzLjgfoHx/powfqpAjvZGTw8PDxcnLxenrzj4/5rgj5x8f///9y6ONcAAAAIHRSTlMAECAgMEBQVlhggZGhobHBwdHR3eHh4+fp7/Hx9/f5+3tefS0AAACkSURBVHjaNc1FAsJAEAXRDj64BAv2IbgEd2s0gfsfiJkAtXurIpkWMQBd0K8O3KZfhWEeW9YB8LnUYY2Gi6WJqJIHwKo7GAMpRT/aV0d2BhRD/Xp7tt9OGs2yYoy5mpUxc0BOc/yvkiQSwJPZtu3XCdAoDtjMb5k8C9KN1utx+zFChsD97bYzRII0Ss2/7IUliILFjZKV8ZLM61xK+V6tsHbSRB+BYB6Vhuib7wAAAABJRU5ErkJggg==">
     </a>
 </p>
@@ -42,12 +42,12 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 | Version | Needs                                |
 |:--------|:-------------------------------------|
-| 1.x     | XCode 8.0+<br>Swift 3.0+<br>iOS 8.0+ |
-| 4.x     | XCode 9.0+<br>Swift 4.0+<br>iOS 8.0+ |
+| 1.x     | Xcode 8.0+<br>Swift 3.0+<br>iOS 8.0+ |
+| 4.x     | Xcode 9.0+<br>Swift 4.0+<br>iOS 8.0+ |
 
 ## Installation
 
-EFCountingLabel is available through [CocoaPods](http://cocoapods.org). To install
+EFCountingLabel is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
@@ -176,4 +176,4 @@ EyreFree, eyrefree@eyrefree.org
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/License_icon-mit-88x31-2.svg/128px-License_icon-mit-88x31-2.svg.png)
 
-EFQRCode is available under the MIT license. See the LICENSE file for more info.
+EFCountingLabel is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
You'll need to change the GitHub description manually to make it HTTPS:
<img width="759" alt="screen shot 2019-03-07 at 15 20 28" src="https://user-images.githubusercontent.com/839992/53938953-bf73af00-40ec-11e9-888a-570a506b94a8.png">
