### PR TITLE
Fix Swift 5.5 compatibility

### DIFF
--- a/EFCountingLabel/EFCountAdapter.swift
+++ b/EFCountingLabel/EFCountAdapter.swift
@@ -26,7 +26,7 @@
 
 import UIKit
 
-public protocol EFCountAdapter: class, EFCount {
+public protocol EFCountAdapter: AnyObject, EFCount {
     var counter: EFCounter { get }
 }
 

--- a/EFCountingLabel/EFTimingMethod.swift
+++ b/EFCountingLabel/EFTimingMethod.swift
@@ -51,7 +51,7 @@ public enum EFTimingFunction: EFTiming {
             }
         case .easeInBounce:
             if time < 4.0 / 11.0 {
-                return 1.0 - (pow(11.0 / 4.0, 2) * pow(time, 2)) - time
+                return 1.0 - (pow(11.0 / 4.0, 2) * pow(time, CGFloat(2))) - time
             } else if time < 8.0 / 11.0 {
                 return 1.0 - (3.0 / 4.0 + pow(11.0 / 4.0, 2) * pow(time - 6.0 / 11.0, 2)) - time
             } else if time < 10.0 / 11.0 {
@@ -60,7 +60,7 @@ public enum EFTimingFunction: EFTiming {
             return 1.0 - (63.0 / 64.0 + pow(11.0 / 4.0, 2) * pow(time - 21.0 / 22.0, 2)) - time
         case .easeOutBounce:
             if time < 4.0 / 11.0 {
-                return pow(11.0 / 4.0, 2) * pow(time, 2)
+                return pow(11.0 / 4.0, 2) * pow(time, CGFloat(2))
             } else if time < 8.0 / 11.0 {
                 return 3.0 / 4.0 + pow(11.0 / 4.0, 2) * pow(time - 6.0 / 11.0, 2)
             } else if time < 10.0 / 11.0 {


### PR DESCRIPTION
Due to SE-0307: https://github.com/apple/swift-evolution/blob/main/proposals/0307-allow-interchangeable-use-of-double-cgfloat-types.md